### PR TITLE
Restamp correctly when not using `hide-immediately`

### DIFF
--- a/iron-lazy-pages.html
+++ b/iron-lazy-pages.html
@@ -204,7 +204,7 @@ of HTTP2 is sufficient enough.
         event.detail.item._loadAndShow(function() {
           this._setLoading(false);
           if (this._lastSelected) {
-            this._lastSelected._hide();
+            this._lastSelected._hide(this.restamp);
           }
         }.bind(this));
       },

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -115,6 +115,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assertStamped('Bar');
         });
 
+        test('remove the dom node when using restamp', function() {
+          pages.restamp = true;
+          fakeImport(0, 'foo.html');
+          pages.selected = 'foo';
+          callbackSuccess();
+          pages.selected = 'nested';
+          // Should contain the three templates and only one node for the selected page
+          assert.equal(Polymer.dom(pages).children.length, 4);
+        });
+
         test('immediately hides when switched', function() {
           pages.hideImmediately = true;
           pages.restamp = true;


### PR DESCRIPTION
Related to TimvdLippe/iron-lazy-pages#12
