### PR TITLE
Fix issue with removing node twice from document head

### DIFF
--- a/iron-lazy-pages.html
+++ b/iron-lazy-pages.html
@@ -311,23 +311,32 @@ of HTTP2 is sufficient enough.
         ##################
        */
 
-      _importHref: function(cb, loadAsync) {
-        if (!this.timesFailed) {
-          this._path = this.path;
-          this.timesFailed = 0;
+      _importHref: (function() {
+        function removeFromHead(e) {
+          var el = e.target || e.srcElement;
+          if (el.parentNode === document.head) {
+            document.head.removeChild(el);
+          }
         }
-        var self = this;
-        this.importHref(this._path, function(e) {
-          self.loaded = true;
-          self.timesFailed = 0;
-          document.head.removeChild(e.target || e.srcElement);
-          cb();
-        }, function(e) {
-          document.head.removeChild(e.target || e.srcElement);
-          self._path = self.path + '?' + self.timesFailed++;
-          cb();
-        }, loadAsync);
-      },
+
+        return function(cb, loadAsync) {
+          if (!this.timesFailed) {
+            this._path = this.path;
+            this.timesFailed = 0;
+          }
+          var self = this;
+          this.importHref(this._path, function(e) {
+            self.loaded = true;
+            self.timesFailed = 0;
+            removeFromHead(e);
+            cb();
+          }, function(e) {
+            removeFromHead(e);
+            self._path = self.path + '?' + self.timesFailed++;
+            cb();
+          }, loadAsync);
+        }
+      })(),
 
       _hide: function(restamp) {
         if (this._instance) {

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -156,7 +156,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           fakeImport(0, 'foo.html');
           pages.select('foo');
           assertStamped('Foo', 1);
-        })
+        });
+
+        test('does not throw error when stamping twice', function() {
+          fakeImport(0, 'foo.html');
+          pages.select('foo');
+          callbackSuccess();
+          fakeImport(1, 'bar.html');
+          pages.select('bar');
+          callbackSuccess();
+          fakeImport(0, 'foo.html');
+          pages.select('foo');
+          callbackSuccess();
+          assertStamped('Foo', 0);
+        });
       });
     </script>
 


### PR DESCRIPTION
Ensure that the node is a child from document.head, to prevent lazy-importing of Polymer 1.6 to crash `iron-lazy-pages`.

Fixes #22 
