### PR TITLE
Handle light DOM distributed template instances

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -24,6 +24,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <style is="custom-style" include="demo-pages-shared-styles"></style>
   </head>
   <body unresolved>
+    <h4 class="centered">Basic usage</h4>
     <demo-snippet class="centered">
       <template>
         <template is="dom-bind">
@@ -38,16 +39,77 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                            loading="{{loading}}"
                            hide-immediately
                            selected-attribute="selected">
-            <template is="iron-lazy-page" data-route="foo" path="element.html">
-              <span>Foo page</span>
+            <template is="iron-lazy-page" data-route="foo" path="x-foo.html">
+              <x-foo></x-foo>
             </template>
-            <template is="iron-lazy-page" data-route="bar" path="bla.html">
-              <span>Bar page</span>
+            <template is="iron-lazy-page" data-route="bar" path="x-bar.html">
+              <x-bar></x-bar>
             </template>
             <template is="iron-lazy-page" data-route="baz">
-              <span>Baz page</span>
+              <h3>Baz page</h3>
+              <span>from inline template</span>
             </template>
           </iron-lazy-pages>
+          <paper-spinner active="[[loading]]"></paper-spinner>
+        </template>
+      </template>
+    </demo-snippet>
+
+    <h4 class="centered">Distribute templates to light DOM</h4>
+    <demo-snippet class="centered">
+      <template>
+        <template is="dom-bind">
+
+          <dom-module id="x-wrapper">
+            <template>
+              <style>
+                :host {
+                  display: block;
+                }
+              </style>
+              <iron-lazy-pages attr-for-selected="data-route"
+                               selected="{{selected}}"
+                               loading="{{loading}}"
+                               selected-attribute="selected"
+                               hide-immediately>
+                <content select="[is=iron-lazy-page]"></content>
+              </iron-lazy-pages>
+            </template>
+            <script>
+              Polymer({
+                is: 'x-wrapper',
+                properties: {
+                  selected: {
+                    type: String,
+                    notify: true
+                  },
+                  loading: {
+                    type: Boolean,
+                    notify: true
+                  }
+                }
+              });
+            </script>
+          </dom-module>
+
+          <paper-tabs selected="{{route}}" attr-for-selected='key'>
+            <paper-tab key="foo">Foo</paper-tab>
+            <paper-tab key="bar">Bar</paper-tab>
+            <paper-tab key="baz">Baz!</paper-tab>
+          </paper-tabs>
+
+          <x-wrapper selected="{{route}}" loading="{{loading}}">
+            <template is="iron-lazy-page" data-route="foo" path="x-foo.html">
+              <x-foo></x-foo>
+            </template>
+            <template is="iron-lazy-page" data-route="bar" path="x-bar.html">
+              <x-bar></x-bar>
+            </template>
+            <template is="iron-lazy-page" data-route="baz">
+              <h3>Baz page</h3>
+              <span>from inline template</span>
+            </template>
+          </x-wrapper>
           <paper-spinner active="[[loading]]"></paper-spinner>
         </template>
       </template>

--- a/demo/x-bar.html
+++ b/demo/x-bar.html
@@ -1,0 +1,9 @@
+<dom-module id="x-bar">
+  <template>
+    <h3>Bar page</h3>
+    <span>from x-bar.html</span>
+  </template>
+  <script>
+    Polymer({ is: 'x-bar' });
+  </script>
+</dom-module>

--- a/demo/x-foo.html
+++ b/demo/x-foo.html
@@ -1,0 +1,9 @@
+<dom-module id="x-foo">
+  <template>
+    <h3>Foo page</h3>
+    <span>from x-foo.html</span>
+  </template>
+  <script>
+    Polymer({ is: 'x-foo' });
+  </script>
+</dom-module>

--- a/iron-lazy-pages.html
+++ b/iron-lazy-pages.html
@@ -194,7 +194,7 @@ of HTTP2 is sufficient enough.
 
       _itemDeselected: function(event) {
         // Do not listen to possible sub-selectors if these fired and iron-deselect
-        if (event.target !== this) {
+        if (Polymer.dom(event).rootTarget !== this) {
           return;
         }
         if (this.hideImmediately) {
@@ -206,7 +206,7 @@ of HTTP2 is sufficient enough.
 
       _itemSelected: function(event) {
         // Do not listen to possible sub-selectors if these fired and iron-select
-        if (event.target !== this) {
+        if (Polymer.dom(event).rootTarget !== this) {
           return;
         }
         this._setLoading(true);
@@ -221,7 +221,7 @@ of HTTP2 is sufficient enough.
           if (this._lastSelected) {
             this._lastSelected._hide(this.restamp, this.selectedAttribute, this.selectedClass);
           }
-        }.bind(this), this.loadAsync);
+        }.bind(this), this);
       },
 
       _filterItem: function(node) {
@@ -253,41 +253,38 @@ of HTTP2 is sufficient enough.
         BEGIN DOM-IF LOGIC
         ##################
        */
-      _loadAndShow: function(cb, loadAsync) {
+      _loadAndShow: function(cb, parent) {
         var onImportFinished = function() {
-          this._stamp();
+          this._stamp(parent);
           cb();
           this._instance._showHideChildren(this.__hideTemplateChildren__);
         }.bind(this);
 
         if (!this.loaded && this.path) {
-          this._importHref(onImportFinished, loadAsync);
+          this._importHref(onImportFinished, parent.loadAsync);
         } else {
           onImportFinished();
         }
       },
 
-      _stamp: function() {
+      _stamp: function(parentNode) {
         if (!this.ctor) {
           this.templatize(this);
         }
         // Attach logic of dom-if
-        var parentNode = Polymer.dom(this).parentNode;
         if (parentNode) {
           var parent = Polymer.dom(parentNode);
+          var target = parent.firstElementChild;
           if (!this._instance) {
             this._instance = this.stamp();
             var root = this._instance.root;
-            parent.insertBefore(root, parent.firstElementChild);
+            parent.insertBefore(root, target);
           } else {
             var c$ = this._instance._children;
             if (c$ && c$.length) {
-              // Detect case where dom-if was re-attached in new position
-              var lastChild = Polymer.dom(this).previousSibling;
-              if (lastChild !== c$[c$.length-1]) {
-                for (var i=0, n; (i<c$.length) && (n=c$[i]); i++) {
-                  parent.insertBefore(n, this);
-                }
+              for (var i = c$.length - 1, n; (i > 0) && (n=c$[i]); i--) {
+                parent.insertBefore(n, target);
+                target = n;
               }
             }
           }

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -40,12 +40,47 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
-    <script>
-      var myEl = document.querySelector('iron-lazy-pages');
+    <test-fixture id="light">
+      <template>
+        <x-wrapper>
+          <template is="iron-lazy-page" data-route="foo" path="foo.html">
+            <span class="foo">Foo</span>
+          </template>
+          <template is="iron-lazy-page" data-route="bar" path="bar.html">
+            <span class="bar">Bar</span>
+          </template>
+          <template is="iron-lazy-page" data-route="nested">
+            <iron-selector selected="0">
+              <section>Something</section>
+              <section>Something Else</section>
+            </iron-selector>
+          </template>
+        </x-wrapper>
+      </template>
+    </test-fixture>
 
+    <dom-module id="x-wrapper">
+      <template>
+        <style>
+          :host {
+            display: block;
+          }
+        </style>
+        <iron-lazy-pages attr-for-selected="data-route" selected-attribute="selected" selected-class="selected">
+          <content select="[is=iron-lazy-page]"></content>
+        </iron-lazy-pages>
+      </template>
+      <script>
+        Polymer({
+          is: 'x-wrapper'
+        });
+      </script>
+    </dom-module>
+
+    <script>
       suite('<iron-lazy-pages>', function() {
 
-        var pages, callbackSuccess, callbackFailure;
+        var pages, wrapper, callbackSuccess, callbackFailure;
 
         function fakeImport(index, expectedPath) {
           var element = document.createElement('span');
@@ -56,7 +91,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               onSuccess({
                 target: element
               });
-            }
+            };
             callbackFailure = function() {
               onFailure({
                 target: element
@@ -64,136 +99,200 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }
           };
         }
-
-        function assertStamped(content, i) {
-          i = i || 0;
+        function assertStamped(content) {
+          var n = Polymer.dom(pages).children.length;
           var node = Polymer.dom(pages).firstElementChild;
-          while (i > 0) {
+          for (var i = 0; i < n; i++) {
+            if (node.tagName !== 'TEMPLATE' && node.tagName !== 'CONTENT') {
+              assert.equal(node.style.display, node.textContent === content ? '' : 'none');
+            }
             node = Polymer.dom(node).nextElementSibling;
-            i--;
           }
-          assert.equal(node.textContent, content);
         }
 
         this.timeout(500);
-        setup(function() {
-          pages = fixture('basic');
-        })
+        suite('basic usage', function() {
+          setup(function() {
+            pages = fixture('basic');
+          });
 
-        test('lazy-loads the path succesfully', function() {
-          fakeImport(0, 'foo.html');
-          pages.select('foo');
-          assert.equal(pages.loading, true);
-          callbackSuccess();
-          assert.equal(pages.loading, false);
+          runCommonTests();
+
+          test('remove the dom node when using restamp', function() {
+            pages.restamp = true;
+            fakeImport(0, 'foo.html');
+            pages.selected = 'foo';
+            callbackSuccess();
+            pages.selected = 'nested';
+            // Should contain the three templates and only one node for the selected page
+            assert.equal(Polymer.dom(pages).children.length, 4);
+          });
+
+          test('immediately hides when switched', function() {
+            pages.hideImmediately = true;
+            pages.restamp = true;
+            fakeImport(0, 'foo.html');
+            pages.select('foo');
+            callbackSuccess();
+            fakeImport(1, 'bar.html');
+            pages.select('bar');
+            assert.equal(Polymer.dom(pages).firstElementChild, pages.items[0]);
+          });
+
+          test('sets selected-class on children', function() {
+            fakeImport(0, 'foo.html');
+            pages.select('foo');
+            callbackSuccess();
+            // expect both <template> and stamped item
+            assert.equal(Polymer.dom(pages).querySelectorAll('.selected').length, 2);
+            fakeImport(1, 'bar.html');
+            pages.select('bar');
+            callbackSuccess();
+            assert.equal(Polymer.dom(pages).querySelectorAll('.selected').length, 2);
+          });
+
+          test('sets selected-attribute on children', function() {
+            fakeImport(0, 'foo.html');
+            pages.select('foo');
+            callbackSuccess();
+            // expect both <template> and stamped item
+            assert.equal(Polymer.dom(pages).querySelectorAll('[selected]').length, 2);
+            fakeImport(1, 'bar.html');
+            pages.select('bar');
+            callbackSuccess();
+            var selectedItems = Polymer.dom(pages).querySelectorAll('[selected]');
+            assert.equal(selectedItems.length, 2, selectedItems);
+          });
         });
 
-        test('sets selected-attribute on children', function() {
-          fakeImport(0, 'foo.html');
-          pages.select('foo');
-          callbackSuccess();
-          assert.equal(Polymer.dom(pages).querySelectorAll('[selected]').length, 2);
-          fakeImport(1, 'bar.html');
-          pages.select('bar');
-          callbackSuccess();
-          var selectedItems = Polymer.dom(pages).querySelectorAll('[selected]');
-          assert.equal(selectedItems.length, 2, selectedItems);
+        suite('light DOM distributed templates', function() {
+          setup(function() {
+            wrapper = fixture('light');
+            pages = wrapper.$$('iron-lazy-pages');
+          });
+
+          runCommonTests();
+
+          test('remove the dom node when using restamp', function() {
+            pages.restamp = true;
+            fakeImport(0, 'foo.html');
+            pages.selected = 'foo';
+            callbackSuccess();
+            pages.selected = 'nested';
+            // Should contain only one node for the selected page and one `<content>` node
+            assert.equal(Polymer.dom(pages).children.length, 2);
+            assert.equal(Polymer.dom(pages).children[1].tagName, 'CONTENT');
+          });
+
+          test('immediately hides when switched', function() {
+            pages.hideImmediately = true;
+            pages.restamp = true;
+            fakeImport(0, 'foo.html');
+            pages.select('foo');
+            callbackSuccess();
+            fakeImport(1, 'bar.html');
+            pages.select('bar');
+            assert.equal(Polymer.dom(wrapper).firstElementChild, pages.items[0]);
+          });
+
+          test('sets selected-class on children', function() {
+            fakeImport(0, 'foo.html');
+            pages.select('foo');
+            callbackSuccess();
+            // <template> is not the `<iron-lazy-pages>` child, expect only stamped item
+            assert.equal(Polymer.dom(pages).querySelectorAll('.selected').length, 1);
+            fakeImport(1, 'bar.html');
+            pages.select('bar');
+            callbackSuccess();
+            assert.equal(Polymer.dom(pages).querySelectorAll('.selected').length, 1);
+          });
+
+          test('sets selected-attribute on children', function() {
+            fakeImport(0, 'foo.html');
+            pages.select('foo');
+            callbackSuccess();
+            // <template> is not the `<iron-lazy-pages>` child, expect only stamped item
+            assert.equal(Polymer.dom(pages).querySelectorAll('[selected]').length, 1);
+            fakeImport(1, 'bar.html');
+            pages.select('bar');
+            callbackSuccess();
+            var selectedItems = Polymer.dom(pages).querySelectorAll('[selected]');
+            assert.equal(selectedItems.length, 1, selectedItems);
+          });
         });
 
-        test('sets selected-class on children', function() {
-          fakeImport(0, 'foo.html');
-          pages.select('foo');
-          callbackSuccess();
-          assert.equal(Polymer.dom(pages).querySelectorAll('.selected').length, 2);
-          fakeImport(1, 'bar.html');
-          pages.select('bar');
-          callbackSuccess();
-          assert.equal(Polymer.dom(pages).querySelectorAll('.selected').length, 2);
-        });
+        function runCommonTests () {
+          test('lazy-loads the path succesfully', function() {
+            fakeImport(0, 'foo.html');
+            pages.select('foo');
+            assert.equal(pages.loading, true);
+            callbackSuccess();
+            assert.equal(pages.loading, false);
+          });
 
-        test('increments counter when failed', function() {
-          fakeImport(0, 'foo.html');
-          pages.select('foo');
-          callbackFailure();
-          pages.select(null);
-          fakeImport(0, 'foo.html?0');
-          pages.select('foo');
-          assert.equal(pages.items[0].timesFailed, 1);
-        });
+          test('increments counter when failed', function() {
+            fakeImport(0, 'foo.html');
+            pages.select('foo');
+            callbackFailure();
+            pages.select(null);
+            fakeImport(0, 'foo.html?0');
+            pages.select('foo');
+            assert.equal(pages.items[0].timesFailed, 1);
+          });
 
-        test('stamps child when loaded', function() {
-          fakeImport(0, 'foo.html');
-          pages.select('foo');
-          callbackSuccess();
-          assertStamped('Foo');
-        });
+          test('stamps child when loaded', function() {
+            fakeImport(0, 'foo.html');
+            pages.select('foo');
+            callbackSuccess();
+            assertStamped('Foo');
+          });
 
-        test('removes previous page when switched', function() {
-          fakeImport(0, 'foo.html');
-          pages.select('foo');
-          callbackSuccess();
-          fakeImport(1, 'bar.html');
-          pages.select('bar');
-          callbackSuccess();
-          assertStamped('Bar');
-        });
+          test('removes previous page when switched', function() {
+            fakeImport(0, 'foo.html');
+            pages.select('foo');
+            callbackSuccess();
+            fakeImport(1, 'bar.html');
+            pages.select('bar');
+            callbackSuccess();
+            assertStamped('Bar');
+          });
 
-        test('remove the dom node when using restamp', function() {
-          pages.restamp = true;
-          fakeImport(0, 'foo.html');
-          pages.selected = 'foo';
-          callbackSuccess();
-          pages.selected = 'nested';
-          // Should contain the three templates and only one node for the selected page
-          assert.equal(Polymer.dom(pages).children.length, 4);
-        });
+          test('does not fail with nested iron-selector', function(done) {
+            pages.select('nested');
+            Polymer.dom(pages).firstElementChild.select(1);
+            // Small timeout to trigger the select event
+            setTimeout(function() {
+              Polymer.dom(pages).firstElementChild.select(0);
+              done();
+            }, 10);
+          });
 
-        test('immediately hides when switched', function() {
-          pages.hideImmediately = true;
-          pages.restamp = true;
-          fakeImport(0, 'foo.html');
-          pages.select('foo');
-          callbackSuccess();
-          fakeImport(1, 'bar.html');
-          pages.select('bar');
-          assert.equal(Polymer.dom(pages).firstElementChild, pages.items[0]);
-        });
+          test('after restamping shows element again', function() {
+            fakeImport(0, 'foo.html');
+            pages.select('foo');
+            callbackSuccess();
+            fakeImport(1, 'bar.html');
+            pages.select('bar');
+            callbackSuccess();
+            fakeImport(0, 'foo.html');
+            pages.select('foo');
+            assertStamped('Foo');
+          });
 
-        test('does not fail with nested iron-selector', function(done) {
-          pages.select('nested');
-          Polymer.dom(pages).firstElementChild.select(1);
-          // Small timeout to trigger the select event
-          setTimeout(function() {
-            Polymer.dom(pages).firstElementChild.select(0);
-            done();
-          }, 10);
-        });
-
-        test('after restamping shows element again', function() {
-          fakeImport(0, 'foo.html');
-          pages.select('foo');
-          callbackSuccess();
-          fakeImport(1, 'bar.html');
-          pages.select('bar');
-          callbackSuccess();
-          fakeImport(0, 'foo.html');
-          pages.select('foo');
-          assertStamped('Foo', 1);
-        });
-
-        test('does not throw error when stamping twice', function() {
-          fakeImport(0, 'foo.html');
-          pages.select('foo');
-          callbackSuccess();
-          fakeImport(1, 'bar.html');
-          pages.select('bar');
-          callbackSuccess();
-          fakeImport(0, 'foo.html');
-          pages.select('foo');
-          callbackSuccess();
-          assertStamped('Foo', 0);
-        });
-      });
+          test('does not throw error when stamping twice', function() {
+            fakeImport(0, 'foo.html');
+            pages.select('foo');
+            callbackSuccess();
+            fakeImport(1, 'bar.html');
+            pages.select('bar');
+            callbackSuccess();
+            fakeImport(0, 'foo.html');
+            pages.select('foo');
+            callbackSuccess();
+            assertStamped('Foo');
+          });
+        }
+     });
     </script>
 
   </body>

--- a/test/index.html
+++ b/test/index.html
@@ -21,6 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Load and run all tests (.html, .js):
       WCT.loadSuites([
         'basic-test.html',
+        'basic-test.html?shadow=1'
       ]);
     </script>
   </body>


### PR DESCRIPTION
This is a workaround to pass `<template>` instances into the light DOM, e. g. like this:

``` html
        <iron-lazy-pages
            id="pages"
            class="pages-wrapper"
            selected="[[selectedTab]]"
            attr-for-selected="tab-name"
            fallback-selection="[[defaultTab]]"
            loading="{{loading}}"
            load-async
        >
            <content select="[is=iron-lazy-page]"></content>
        </iron-lazy-pages>
```

Not sure if I do the stuff correct (although it seems to work), especially interested in handling differences in `shady` and `shadow` DOM modes.
@TimvdLippe PTAL. I'm waiting for your feedback, as well as your opinion about how to test this.
