### PR TITLE
Set selected-attribute and selected-class on stamped elements

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -36,15 +36,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <iron-lazy-pages attr-for-selected="data-route"
                            selected="{{route}}"
                            loading="{{loading}}"
-                           hide-immediately>
+                           hide-immediately
+                           selected-attribute="selected">
             <template is="iron-lazy-page" data-route="foo" path="element.html">
-              Foo page
+              <span>Foo page</span>
             </template>
             <template is="iron-lazy-page" data-route="bar" path="bla.html">
-              Bar page
+              <span>Bar page</span>
             </template>
             <template is="iron-lazy-page" data-route="baz">
-              Baz page
+              <span>Baz page</span>
             </template>
           </iron-lazy-pages>
           <paper-spinner active="[[loading]]"></paper-spinner>

--- a/iron-lazy-pages.html
+++ b/iron-lazy-pages.html
@@ -198,7 +198,7 @@ of HTTP2 is sufficient enough.
           return;
         }
         if (this.hideImmediately) {
-          event.detail.item._hide(this.restamp);
+          event.detail.item._hide(this.restamp, this.selectedAttribute, this.selectedClass);
         } else {
           this._lastSelected = event.detail.item;
         }
@@ -211,9 +211,15 @@ of HTTP2 is sufficient enough.
         }
         this._setLoading(true);
         event.detail.item._loadAndShow(function() {
+          if (this.selectedAttribute) {
+            event.detail.item._toggleAttribute(this.selectedAttribute, true);
+          }
+          if (this.selectedClass) {
+            event.detail.item._toggleClass(this.selectedClass, true);
+          }
           this._setLoading(false);
           if (this._lastSelected) {
-            this._lastSelected._hide(this.restamp);
+            this._lastSelected._hide(this.restamp, this.selectedAttribute, this.selectedClass);
           }
         }.bind(this), this.loadAsync);
       },
@@ -249,8 +255,8 @@ of HTTP2 is sufficient enough.
        */
       _loadAndShow: function(cb, loadAsync) {
         var onImportFinished = function() {
-          cb();
           this._stamp();
+          cb();
           this._instance._showHideChildren(this.__hideTemplateChildren__);
         }.bind(this);
 
@@ -338,7 +344,7 @@ of HTTP2 is sufficient enough.
         }
       })(),
 
-      _hide: function(restamp) {
+      _hide: function(restamp, attribute, clazz) {
         if (this._instance) {
           if (restamp) {
             var c$ = this._instance._children;
@@ -352,6 +358,45 @@ of HTTP2 is sufficient enough.
             this._instance = null;
           } else {
             this._instance._showHideChildren(true);
+            if (attribute) {
+              this._toggleAttribute(attribute, false);
+            }
+            if (clazz) {
+              this._toggleClass(clazz, false);
+            }
+          }
+        }
+      },
+
+      _toggleClass: function(clazz, bool) {
+        this._forEachHtmlElement(function(n) {
+          if (bool) {
+            n.classList.add(clazz);
+          } else {
+            n.classList.remove(clazz);
+          }
+        });
+      },
+
+      _toggleAttribute: function(attribute, bool) {
+        this._forEachHtmlElement(function(n) {
+          if (bool) {
+            n.setAttribute(attribute, '');
+          } else {
+            n.removeAttribute(attribute);
+          }
+        });
+      },
+
+      _forEachHtmlElement: function(func) {
+        if (this._instance) {
+          var c$ = this._instance._children;
+          if (c$ && c$.length) {
+            for (var i=0, n; (i<c$.length) && (n=c$[i]); i++) {
+              if (n instanceof HTMLElement) {
+                func(Polymer.dom(n));
+              }
+            }
           }
         }
       }

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -23,7 +23,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <test-fixture id="basic">
       <template>
-        <iron-lazy-pages attr-for-selected="data-route">
+        <iron-lazy-pages attr-for-selected="data-route" selected-attribute="selected" selected-class="selected">
           <template is="iron-lazy-page" data-route="foo" path="foo.html">
             <span>Foo</span>
           </template>
@@ -86,6 +86,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(pages.loading, true);
           callbackSuccess();
           assert.equal(pages.loading, false);
+        });
+
+        test('sets selected-attribute on children', function() {
+          fakeImport(0, 'foo.html');
+          pages.select('foo');
+          callbackSuccess();
+          assert.equal(Polymer.dom(pages).querySelectorAll('[selected]').length, 2);
+          fakeImport(1, 'bar.html');
+          pages.select('bar');
+          callbackSuccess();
+          var selectedItems = Polymer.dom(pages).querySelectorAll('[selected]');
+          assert.equal(selectedItems.length, 2, selectedItems);
+        });
+
+        test('sets selected-class on children', function() {
+          fakeImport(0, 'foo.html');
+          pages.select('foo');
+          callbackSuccess();
+          assert.equal(Polymer.dom(pages).querySelectorAll('.selected').length, 2);
+          fakeImport(1, 'bar.html');
+          pages.select('bar');
+          callbackSuccess();
+          assert.equal(Polymer.dom(pages).querySelectorAll('.selected').length, 2);
         });
 
         test('increments counter when failed', function() {


### PR DESCRIPTION
Add compatibility for `selected-class` and `selected-attribute` of `iron-selector`. These attributes/classes are added to all stamped HTMLElements.

Fixes #25
