### PR TITLE
Fix light DOM children stamping to shadow DOM

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -77,7 +77,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                                loading="{{loading}}"
                                selected-attribute="selected"
                                hide-immediately>
-                <content select="[is=iron-lazy-page]"></content>
+                <content></content>
               </iron-lazy-pages>
             </template>
             <script>

--- a/iron-lazy-page.html
+++ b/iron-lazy-page.html
@@ -30,8 +30,9 @@ Polymer({
     BEGIN DOM-IF LOGIC
     ##################
    */
-   _loadAndShow: function(cb, parent) {
+   _loadAndShow: function(cb) {
      var self = this;
+     var parent = self.parentNode;
      var onImportFinished = function() {
        cb(function() {
          self._stamp(parent);

--- a/iron-lazy-page.html
+++ b/iron-lazy-page.html
@@ -34,7 +34,7 @@ Polymer({
      var self = this;
      var onImportFinished = function() {
        cb(function() {
-         self._stamp(self.parentNode);
+         self._stamp(Polymer.dom(self).parentNode);
          self._instance._showHideChildren(false);
          return self;
        })

--- a/iron-lazy-page.html
+++ b/iron-lazy-page.html
@@ -30,12 +30,11 @@ Polymer({
     BEGIN DOM-IF LOGIC
     ##################
    */
-   _loadAndShow: function(cb) {
+   _loadAndShow: function(cb, parent) {
      var self = this;
-     var parent = self.parentNode;
      var onImportFinished = function() {
        cb(function() {
-         self._stamp(parent);
+         self._stamp(self.parentNode);
          self._instance._showHideChildren(false);
          return self;
        })

--- a/iron-lazy-pages-behavior.html
+++ b/iron-lazy-pages-behavior.html
@@ -93,7 +93,7 @@ Polymer.IronLazyPagesBehaviorImpl = {
       if (this.selectedClass) {
         event.detail.item._toggleClass(this.selectedClass, true);
       }
-    }.bind(this));
+    }.bind(this), this);
   },
 
   _filterItem: function(node) {

--- a/iron-lazy-pages-behavior.html
+++ b/iron-lazy-pages-behavior.html
@@ -93,7 +93,7 @@ Polymer.IronLazyPagesBehaviorImpl = {
       if (this.selectedClass) {
         event.detail.item._toggleClass(this.selectedClass, true);
       }
-    }.bind(this), this);
+    }.bind(this));
   },
 
   _filterItem: function(node) {

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -67,7 +67,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
         </style>
         <iron-lazy-pages attr-for-selected="data-route" selected-attribute="selected" selected-class="selected">
-          <content select="[is=iron-lazy-page]"></content>
+          <content></content>
         </iron-lazy-pages>
       </template>
       <script>
@@ -179,9 +179,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             pages.selected = 'foo';
             callbackSuccess();
             pages.selected = 'nested';
-            // Should contain only one node for the selected page and one `<content>` node
-            assert.equal(Polymer.dom(pages).children.length, 2);
-            assert.equal(Polymer.dom(pages).children[1].tagName, 'CONTENT');
+            assert.equal(Polymer.dom(pages).querySelector('.foo'), null)
+            assert.equal(wrapper.querySelector('.foo'), null);
           });
 
           test('immediately hides when switched', function() {
@@ -199,25 +198,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             fakeImport(0, 'foo.html');
             pages.select('foo');
             callbackSuccess();
-            // <template> is not the `<iron-lazy-pages>` child, expect only stamped item
-            assert.equal(Polymer.dom(pages).querySelectorAll('.selected').length, 1);
-            fakeImport(1, 'bar.html');
-            pages.select('bar');
-            callbackSuccess();
-            assert.equal(Polymer.dom(pages).querySelectorAll('.selected').length, 1);
+            assert.isAbove(wrapper.querySelectorAll('.selected').length, 0);
           });
 
           test('sets selected-attribute on children', function() {
             fakeImport(0, 'foo.html');
             pages.select('foo');
             callbackSuccess();
-            // <template> is not the `<iron-lazy-pages>` child, expect only stamped item
-            assert.equal(Polymer.dom(pages).querySelectorAll('[selected]').length, 1);
-            fakeImport(1, 'bar.html');
-            pages.select('bar');
-            callbackSuccess();
-            var selectedItems = Polymer.dom(pages).querySelectorAll('[selected]');
-            assert.equal(selectedItems.length, 1, selectedItems);
+            assert.isAbove(wrapper.querySelectorAll('[selected]').length, 0);
           });
         });
 
@@ -259,10 +247,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           test('does not fail with nested iron-selector', function(done) {
             pages.select('nested');
-            Polymer.dom(pages).firstElementChild.select(1);
+            var shadow = Polymer.dom(pages).querySelector('iron-selector');
+            var shady = Polymer.dom(wrapper).querySelector('iron-selector');
+
+            shadow ? shadow.select(1) : shady.select(1);
             // Small timeout to trigger the select event
             setTimeout(function() {
-              Polymer.dom(pages).firstElementChild.select(0);
+              shadow ? shadow.select(1) : shady.select(1);
               done();
             }, 10);
           });

--- a/test/index.html
+++ b/test/index.html
@@ -21,7 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Load and run all tests (.html, .js):
       WCT.loadSuites([
         'basic-test.html',
-        'basic-test.html?shadow=1'
+        'basic-test.html?dom=shadow'
       ]);
     </script>
   </body>


### PR DESCRIPTION
Stamps template to its parent, rather than as child of iron-lazy-pages.

Fixes #32
