### PR TITLE
Add missing polymer.html import

### DIFF
--- a/iron-lazy-page.html
+++ b/iron-lazy-page.html
@@ -6,6 +6,8 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license.  See the LICENSE file for details.
 -->
+<link rel="import" href="../polymer/polymer.html">
+
 <!--
 Template element used in conjunction with `iron-lazy-pages`.
 


### PR DESCRIPTION
This is required to use this element with new `polymer-build` 0.5.0

@TimvdLippe PTAL.

Fixes #39