### PR TITLE
Fix "Polymer is not defined" in tests

### DIFF
--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -71,8 +71,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </iron-lazy-pages>
       </template>
       <script>
-        Polymer({
-          is: 'x-wrapper'
+        HTMLImports.whenReady(function () {
+          Polymer({
+            is: 'x-wrapper'
+          });
         });
       </script>
     </dom-module>


### PR DESCRIPTION
I had Polymer is not defined on firefox making tests timeout.