### PR TITLE
Let the analyzer infer the names of behaviors

### DIFF
--- a/iron-lazy-pages-behavior.html
+++ b/iron-lazy-pages-behavior.html
@@ -9,7 +9,7 @@ of the BSD license.  See the LICENSE file for details.
 <link rel="import" href="../iron-selector/iron-selectable.html">
 
 <script>
-/** @polymerBehavior Polymer.IronLazyPagesBehavior */
+/** @polymerBehavior */
 Polymer.IronLazyPagesBehaviorImpl = {
   properties: {
     // as the selected page is the only one visible, activateEvent
@@ -114,6 +114,7 @@ Polymer.IronLazyPagesBehaviorImpl = {
   }
 };
 
+/** @polymerBehavior */
 Polymer.IronLazyPagesBehavior = [
   Polymer.IronSelectableBehavior,
   Polymer.IronLazyPagesBehaviorImpl


### PR DESCRIPTION
By explicitly having the name on the Impl, the analyzer was taking the annotation at its word, but missing that it used IronSelectableBehavior.

Fixes https://github.com/Polymer/polymer-linter/issues/70