### PR TITLE
Add support for dom-if

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,24 @@ will be hidden.
 
 Fetching is only performed once, e.g. switching from `foo` to `bar` to `foo` will fetch
 `foo` once and show `foo` twice.
+
+## `<dom-if>` support
+
+You can also add `<dom-if>` as a route to enable restamping:
+
+```html
+<iron-lazy-pages
+    attr-for-selected="data-route"
+    selected="{{route}}"
+    loading="{{loading}}"
+    hide-immediately>
+  <template is="dom-if" data-route="foo" restamp>
+    Leaving this tab and coming back will loose input value due to restamp<br/>
+    <input type="text"/>
+  </template>
+  <template is="dom-if" data-route="bar">
+    Leaving this tab and coming back will keep input value<br/>
+    <input type="text"/>
+  </template>
+</iron-lazy-pages>
+```

--- a/demo/index.html
+++ b/demo/index.html
@@ -65,6 +65,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 </template>
                 <template is="dom-if" data-route="dom-if-input" restamp>
                   <label>This is a text field that, if the page is deselected, is cleared due to restamp <input type="text"/></label>
+                  <div>
+                    <label>Click this button to test if nested dom-ifs work <input type="checkbox" checked="{{hostChecked::change}}" /></label>
+                    <template is="dom-if" if="[[hostChecked]]">
+                      <div>
+                        Tests
+                      </div>
+                    </template>
+                  </div>
                 </template>
               </iron-lazy-pages>
               <paper-spinner active="[[loading]]"></paper-spinner>

--- a/demo/index.html
+++ b/demo/index.html
@@ -43,6 +43,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               <paper-tab key='foo'>Foo</paper-tab>
               <paper-tab key='bar'>Bar</paper-tab>
               <paper-tab key='baz'>Baz!</paper-tab>
+              <paper-tab key='dom-if'>dom-if</paper-tab>
             </paper-tabs>
 
             <div>
@@ -57,6 +58,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                   <h3>Baz page</h3>
                   <span>from inline template</span>
                 </div>
+                <template is="dom-if" data-route="dom-if">
+                  Another inline template inside a dom-if
+                </template>
               </iron-lazy-pages>
               <paper-spinner active="[[loading]]"></paper-spinner>
             </div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -44,6 +44,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               <paper-tab key='bar'>Bar</paper-tab>
               <paper-tab key='baz'>Baz!</paper-tab>
               <paper-tab key='dom-if'>dom-if</paper-tab>
+              <paper-tab key='dom-if-input'>dom-if with input</paper-tab>
             </paper-tabs>
 
             <div>
@@ -60,6 +61,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 </div>
                 <template is="dom-if" data-route="dom-if">
                   Another inline template inside a dom-if
+                  <label>This is a text field that, if the page is deselected, keeps it text <input type="text"/></label>
+                </template>
+                <template is="dom-if" data-route="dom-if-input" restamp>
+                  <label>This is a text field that, if the page is deselected, is cleared due to restamp <input type="text"/></label>
                 </template>
               </iron-lazy-pages>
               <paper-spinner active="[[loading]]"></paper-spinner>

--- a/iron-lazy-pages-behavior.html
+++ b/iron-lazy-pages-behavior.html
@@ -40,6 +40,25 @@ Polymer.IronLazyPagesBehaviorImpl = {
     hideImmediately: {
       type: Boolean,
       value: false
+    },
+
+    /**
+     * The set of excluded elements where the key is the `localName`
+     * of the element that will be ignored from the item list.
+     *
+     * @default {template: 1}
+     */
+    _excludedLocalNames: {
+      type: Object,
+      value: function() {
+        return {
+          // 'template': 1,
+          'dom-bind': 1,
+          // Explicitly opt-in for `dom-if`
+          // 'dom-if': 1,
+          'dom-repeat': 1,
+        };
+      }
     }
   },
 
@@ -54,6 +73,7 @@ Polymer.IronLazyPagesBehaviorImpl = {
       return;
     }
     if (this.hideImmediately) {
+      event.detail.item['if'] = false;
       event.detail.item.classList.remove('iron-lazy-selected');
     } else {
       this._lastSelected = event.detail.item;
@@ -97,10 +117,12 @@ Polymer.IronLazyPagesBehaviorImpl = {
 
   _show: function(page) {
     if (this._lastSelected) {
+      this._lastSelected['if'] = false;
       this._lastSelected.classList.remove('iron-lazy-selected');
     }
 
     page.classList.add('iron-lazy-selected');
+    page['if'] = true;
   }
 };
 

--- a/iron-lazy-pages-behavior.html
+++ b/iron-lazy-pages-behavior.html
@@ -62,6 +62,18 @@ Polymer.IronLazyPagesBehaviorImpl = {
     }
   },
 
+  attached: function() {
+    this.addEventListener('dom-change', function(event) {
+      var target = event.target;
+      if (target['if']) {
+        var sibling = target;
+        while ((sibling = sibling.previousElementSibling) != this.__previousSibling) {
+          sibling.classList.add('iron-lazy-selected');
+        }
+      }
+    }.bind(this));
+  },
+
   listeners: {
     'iron-deselect': '_itemDeselected',
     'iron-select': '_itemSelected'
@@ -123,6 +135,7 @@ Polymer.IronLazyPagesBehaviorImpl = {
 
     page.classList.add('iron-lazy-selected');
     page['if'] = true;
+    this.__previousSibling = page.previousElementSibling;
   }
 };
 

--- a/iron-lazy-pages-behavior.html
+++ b/iron-lazy-pages-behavior.html
@@ -64,6 +64,10 @@ Polymer.IronLazyPagesBehaviorImpl = {
 
   attached: function() {
     this.addEventListener('dom-change', function(event) {
+      // Do not listen to possible sub-selectors if these fired and iron-deselect
+      if (event.target.parentNode !== this) {
+        return;
+      }
       var target = event.target;
       if (target['if']) {
         var sibling = target;

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -30,6 +30,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <section>Something</section>
             <section>Something Else</section>
           </iron-selector>
+          <dom-if data-route="dom-if">
+            <template is="dom-if">
+              <div class="dom-if-stamped"></div>
+            </template>
+          </dom-if>
         </iron-lazy-pages>
       </template>
     </test-fixture>
@@ -77,6 +82,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         commonTests();
+
+        test('sets dom-if to true', function(done) {
+          pages.addEventListener('iron-items-changed', function() {
+            assert.isTrue(pages.items[3]['if']);
+            // Polymer 2 version
+            if (pages.items[3].__render) {
+              pages.addEventListener('dom-change', function() {
+                assert.notEqual(pages.querySelector('.dom-if-stamped', null));
+                done();
+              })
+            // Polymer 1 version
+            } else {
+              done();
+            }
+          });
+          Polymer.Base.importHref = function(url, onSuccess) {
+            onSuccess();
+          };
+          pages.selected = 'dom-if';
+        });
 
         suite('light-dom', function() {
           setup(function() {


### PR DESCRIPTION
This should support `dom-if` by setting the `if` property on the page to true/false to trigger the restamping. Please let me know if it works in your usecase when migrating from `iron-lazy-pages` 1 to 2.

Fixes #54 