### PR TITLE
Fix resolving when the parentNode of iron-lazy-pages is not the element host

### DIFF
--- a/demo/foo.html
+++ b/demo/foo.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+  <link rel="import" href="src/my-app.html" />
+</head>
+<body>
+  <my-app></my-app>
+</body>
+</html>

--- a/demo/src/my-app.html
+++ b/demo/src/my-app.html
@@ -1,0 +1,18 @@
+<link rel="import" href="../../iron-lazy-pages.html" />
+
+<dom-module id="my-app">
+  <template>
+    <section>
+      <iron-lazy-pages>
+        <section data-path="my-demo.html">
+          <my-demo></my-demo>
+        </section>
+      </iron-lazy-pages>
+    </template>
+    </section>
+  <script>
+    Polymer({
+      is: 'my-app'
+    })
+  </script>
+</dom-module>

--- a/demo/src/my-demo.html
+++ b/demo/src/my-demo.html
@@ -1,0 +1,10 @@
+<dom-module id="my-demo">
+  <template>
+    <span>Fooo</span>
+  </template>
+  <script>
+    Polymer({
+      is: 'my-demo'
+    })
+  </script>
+</dom-module>

--- a/iron-lazy-pages-behavior.html
+++ b/iron-lazy-pages-behavior.html
@@ -87,8 +87,16 @@ Polymer.IronLazyPagesBehaviorImpl = {
    */
   _loadPage: function(page, onFinished) {
     // When not loaded in shadow dom, `this.parentNode.host` is undefined. Resort back to the parentNode
-    var parentNode = this.parentNode && this.parentNode.host || this.parentNode;
-    var url = parentNode.resolveUrl && parentNode.resolveUrl(page.dataset.path) || page.dataset.path;
+    var parentHost = this.parentNode;
+    while (parentHost && parentHost.nodeName !== '#document-fragment') {
+      parentHost = parentHost.parentNode;
+    }
+    var url;
+    if (parentHost && parentHost.host &&  parentHost.host.resolveUrl) {
+      url = parentHost.host.resolveUrl(page.dataset.path);
+    } else {
+      url = page.dataset.path;
+    }
     Polymer.Base.importHref(url, function() {
       page.classList.add('iron-lazy-loaded');
       onFinished();


### PR DESCRIPTION
If the parentNode of iron-lazy-pages is a different element,
for example an app-skeleton element, we should not resolve by the parentNode
but by the host instead.

Fixes #57